### PR TITLE
Updates API to latest release

### DIFF
--- a/Editor/TextureAtlasSlicer.cs
+++ b/Editor/TextureAtlasSlicer.cs
@@ -34,10 +34,9 @@ public class TextureAtlasSlicer : EditorWindow
     {
         var textureImporter = command.context as TextureImporter;
 
-        //valid only if the texture type is 'sprite' or 'advanced'.
+        //valid only if the texture type is 'sprite' or 'default'.
         return textureImporter && textureImporter.textureType == TextureImporterType.Sprite ||
-               textureImporter.textureType == TextureImporterType.Default ||
-               textureImporter.textureType == TextureImporterType.Advanced;
+               textureImporter.textureType == TextureImporterType.Default;
     }
 
     public TextureImporter importer;
@@ -316,10 +315,9 @@ public class TextureAtlasSlicer : EditorWindow
             EditorGUI.EndDisabledGroup();
 
             if (importer.textureType != TextureImporterType.Sprite &&
-                importer.textureType != TextureImporterType.Default &&
-                importer.textureType != TextureImporterType.Advanced)
+                importer.textureType != TextureImporterType.Default)
             {
-                EditorGUILayout.LabelField("The Texture Type needs to be Sprite, Default or Advanced!");
+                EditorGUILayout.LabelField("The Texture Type needs to be Sprite or Default!");
             }
 
             EditorGUI.BeginDisabledGroup((importer.textureType != TextureImporterType.Sprite &&


### PR DESCRIPTION
New versions of the Unity API no longer have the ['Advanced' texture type](https://docs.unity3d.com/2020.1/Documentation/ScriptReference/TextureImporterType.html).